### PR TITLE
World data storage + lock weather command

### DIFF
--- a/src/main/java/io/github/essencepowered/essence/NameUtil.java
+++ b/src/main/java/io/github/essencepowered/essence/NameUtil.java
@@ -5,7 +5,7 @@
 package io.github.essencepowered.essence;
 
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;

--- a/src/main/java/io/github/essencepowered/essence/api/data/EssenceWorld.java
+++ b/src/main/java/io/github/essencepowered/essence/api/data/EssenceWorld.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.api.data;
+
+import io.github.essencepowered.essence.Essence;
+
+/**
+ * Represents data held about a world in {@link Essence}.
+ */
+public interface EssenceWorld {
+
+    /**
+     * Gets whether the weather has been locked in this world.
+     *
+     * @return <code>true</code> if the weather has been locked.
+     */
+    boolean isLockWeather();
+
+    /**
+     * Sets whether the weather has been locked in this world.
+     *
+     * @param lockWeather <code>true</code> if the weather should be locked, <code>false</code> otherwise.
+     */
+    void setLockWeather(boolean lockWeather);
+}

--- a/src/main/java/io/github/essencepowered/essence/api/service/EssenceUserLoaderService.java
+++ b/src/main/java/io/github/essencepowered/essence/api/service/EssenceUserLoaderService.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 /**
  * A service that retrieves {@link EssenceUser}s.
  */
-public interface EssenceUserService {
+public interface EssenceUserLoaderService {
 
     /**
      * Gets a list of {@link EssenceUser}s that represents the online.

--- a/src/main/java/io/github/essencepowered/essence/api/service/EssenceWorldLoaderService.java
+++ b/src/main/java/io/github/essencepowered/essence/api/service/EssenceWorldLoaderService.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.api.service;
+
+import io.github.essencepowered.essence.api.data.EssenceWorld;
+import io.github.essencepowered.essence.api.exceptions.NoSuchWorldException;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.world.World;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * A service that retrieves {@link EssenceWorld}s.
+ */
+public interface EssenceWorldLoaderService {
+
+    /**
+     * Gets the world associated with the provided UUID.
+     * @param uuid The {@link UUID} of the world to load.
+     * @return The {@link EssenceWorld} that contains the Essenence data for the world.
+     *
+     * @throws NoSuchWorldException If the world does not exist.
+     * @throws IOException If the data file could not be read
+     * @throws ObjectMappingException If the data file is malformed.
+     */
+    EssenceWorld getWorld(UUID uuid) throws NoSuchWorldException, IOException, ObjectMappingException;
+
+    /**
+     * Gets the world associated with the provided UUID.
+     * @param world The {@link World} to load.
+     * @return The {@link EssenceWorld} that contains the Essenence data for the world.
+     *
+     * @throws IOException If the data file could not be read
+     * @throws ObjectMappingException If the data file is malformed.
+     */
+    EssenceWorld getWorld(World world) throws IOException, ObjectMappingException;
+
+    /**
+     * Saves all world data.
+     */
+    void saveAll();
+}

--- a/src/main/java/io/github/essencepowered/essence/commands/core/ResetUser.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/core/ResetUser.java
@@ -9,7 +9,7 @@ import io.github.essencepowered.essence.Util;
 import io.github.essencepowered.essence.argumentparsers.UserParser;
 import io.github.essencepowered.essence.internal.CommandBase;
 import io.github.essencepowered.essence.internal.annotations.*;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;

--- a/src/main/java/io/github/essencepowered/essence/commands/environment/LockWeatherCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/environment/LockWeatherCommand.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.commands.environment;
+
+import com.google.inject.Inject;
+import io.github.essencepowered.essence.Util;
+import io.github.essencepowered.essence.api.PluginModule;
+import io.github.essencepowered.essence.api.data.EssenceWorld;
+import io.github.essencepowered.essence.internal.CommandBase;
+import io.github.essencepowered.essence.internal.annotations.*;
+import io.github.essencepowered.essence.internal.services.datastore.WorldConfigLoader;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.source.LocatedSource;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.world.storage.WorldProperties;
+
+import java.util.Optional;
+
+/**
+ * Locks (or unlocks) the weather.
+ *
+ * Permission: essence.lockweather.base
+ */
+@Permissions
+@RunAsync
+@Modules(PluginModule.ENVIRONMENT)
+@RegisterCommand({ "lockweather", "killweather" })
+@NoWarmup
+@NoCooldown
+@NoCost
+public class LockWeatherCommand extends CommandBase<CommandSource> {
+
+    @Inject private WorldConfigLoader loader;
+
+    private final String worldKey = "world";
+    private final String toggleKey = "toggle";
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().arguments(
+                GenericArguments.onlyOne(GenericArguments.optionalWeak(GenericArguments.world(Text.of(worldKey)))),
+                GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.bool(Text.of(toggleKey))))
+        ).executor(this).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<WorldProperties> world = args.<WorldProperties>getOne(worldKey);
+        WorldProperties wp;
+        if (world.isPresent()) {
+            // World was specified
+            wp = world.get();
+        } else if (src instanceof LocatedSource) {
+            // Player/CommandBlock world
+            wp = ((LocatedSource) src).getWorld().getProperties();
+        } else {
+            // Default world - console!
+            src.sendMessage(Text.of(TextColors.RED, Util.getMessageWithFormat("command.specifyworld")));
+            return CommandResult.empty();
+        }
+
+        EssenceWorld ws = loader.getWorld(wp.getUniqueId());
+        boolean toggle = args.<Boolean>getOne(toggleKey).orElse(!ws.isLockWeather());
+
+        ws.setLockWeather(toggle);
+        if (toggle) {
+            src.sendMessage(Text.of(TextColors.GREEN, Util.getMessageWithFormat("command.lockweather.locked", wp.getWorldName())));
+        } else {
+            src.sendMessage(Text.of(TextColors.GREEN, Util.getMessageWithFormat("command.lockweather.unlocked", wp.getWorldName())));
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/commands/message/SocialSpyCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/message/SocialSpyCommand.java
@@ -11,7 +11,7 @@ import io.github.essencepowered.essence.api.data.EssenceUser;
 import io.github.essencepowered.essence.internal.CommandBase;
 import io.github.essencepowered.essence.internal.annotations.*;
 import io.github.essencepowered.essence.internal.permissions.SuggestedLevel;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;

--- a/src/main/java/io/github/essencepowered/essence/commands/mute/CheckMuteCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/mute/CheckMuteCommand.java
@@ -13,7 +13,7 @@ import io.github.essencepowered.essence.argumentparsers.UserParser;
 import io.github.essencepowered.essence.internal.CommandBase;
 import io.github.essencepowered.essence.internal.annotations.*;
 import io.github.essencepowered.essence.internal.permissions.SuggestedLevel;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandException;

--- a/src/main/java/io/github/essencepowered/essence/commands/mute/MuteCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/mute/MuteCommand.java
@@ -16,7 +16,7 @@ import io.github.essencepowered.essence.internal.CommandPermissionHandler;
 import io.github.essencepowered.essence.internal.annotations.*;
 import io.github.essencepowered.essence.internal.permissions.PermissionInformation;
 import io.github.essencepowered.essence.internal.permissions.SuggestedLevel;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;

--- a/src/main/java/io/github/essencepowered/essence/commands/nickname/DelNickCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/nickname/DelNickCommand.java
@@ -13,7 +13,7 @@ import io.github.essencepowered.essence.internal.annotations.Modules;
 import io.github.essencepowered.essence.internal.annotations.Permissions;
 import io.github.essencepowered.essence.internal.annotations.RegisterCommand;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;

--- a/src/main/java/io/github/essencepowered/essence/commands/nickname/NicknameCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/nickname/NicknameCommand.java
@@ -16,7 +16,7 @@ import io.github.essencepowered.essence.internal.annotations.RegisterCommand;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
 import io.github.essencepowered.essence.internal.permissions.PermissionInformation;
 import io.github.essencepowered.essence.internal.permissions.SuggestedLevel;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;

--- a/src/main/java/io/github/essencepowered/essence/commands/playerinfo/ListPlayerCommand.java
+++ b/src/main/java/io/github/essencepowered/essence/commands/playerinfo/ListPlayerCommand.java
@@ -15,7 +15,7 @@ import io.github.essencepowered.essence.internal.annotations.RegisterCommand;
 import io.github.essencepowered.essence.internal.annotations.RunAsync;
 import io.github.essencepowered.essence.internal.permissions.PermissionInformation;
 import io.github.essencepowered.essence.internal.permissions.SuggestedLevel;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;

--- a/src/main/java/io/github/essencepowered/essence/config/serialisers/WorldConfig.java
+++ b/src/main/java/io/github/essencepowered/essence/config/serialisers/WorldConfig.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.config.serialisers;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+/**
+ * Contains the config entries for any World Config.
+ */
+@ConfigSerializable
+public class WorldConfig {
+    @Setting("lock-weather")
+    private boolean lockWeather = false;
+
+    public boolean isLockWeather() {
+        return lockWeather;
+    }
+
+    public void setLockWeather(boolean lockWeather) {
+        this.lockWeather = lockWeather;
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/internal/guice/QuickStartInjectorModule.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/guice/QuickStartInjectorModule.java
@@ -10,18 +10,21 @@ import io.github.essencepowered.essence.config.CommandsConfig;
 import io.github.essencepowered.essence.config.MainConfig;
 import io.github.essencepowered.essence.internal.ConfigMap;
 import io.github.essencepowered.essence.internal.PermissionRegistry;
-import io.github.essencepowered.essence.internal.services.*;
+import io.github.essencepowered.essence.internal.services.JailHandler;
+import io.github.essencepowered.essence.internal.services.MailHandler;
+import io.github.essencepowered.essence.internal.services.TeleportHandler;
+import io.github.essencepowered.essence.internal.services.WarmupManager;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.WorldConfigLoader;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Sponge;
 
 public class QuickStartInjectorModule extends AbstractModule {
     private final Essence plugin;
-    private final UserConfigLoader loader;
 
-    public QuickStartInjectorModule(Essence plugin, UserConfigLoader configLoader) {
+    public QuickStartInjectorModule(Essence plugin) {
         this.plugin = plugin;
-        this.loader = configLoader;
     }
 
     @Override
@@ -30,7 +33,8 @@ public class QuickStartInjectorModule extends AbstractModule {
         bind(Logger.class).toProvider(plugin::getLogger);
         bind(MainConfig.class).toProvider(() -> plugin.getConfig(ConfigMap.MAIN_CONFIG).get());
         bind(CommandsConfig.class).toProvider(() -> plugin.getConfig(ConfigMap.COMMANDS_CONFIG).get());
-        bind(UserConfigLoader.class).toProvider(() -> loader);
+        bind(UserConfigLoader.class).toProvider(plugin::getUserLoader);
+        bind(WorldConfigLoader.class).toProvider(plugin::getWorldLoader);
         bind(Game.class).toProvider(Sponge::getGame);
         bind(MailHandler.class).toProvider(plugin::getMailHandler);
         bind(JailHandler.class).toProvider(plugin::getJailHandler);

--- a/src/main/java/io/github/essencepowered/essence/internal/services/MessageHandler.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/services/MessageHandler.java
@@ -9,7 +9,7 @@ import com.google.common.collect.Maps;
 import io.github.essencepowered.essence.NameUtil;
 import io.github.essencepowered.essence.Util;
 import io.github.essencepowered.essence.api.data.EssenceUser;
-import io.github.essencepowered.essence.api.service.EssenceUserService;
+import io.github.essencepowered.essence.api.service.EssenceUserLoaderService;
 import io.github.essencepowered.essence.events.MessageEvent;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
@@ -74,7 +74,7 @@ public class MessageHandler {
         Text nameOfSender = getName(sender);
         Text nameOfReceiver = getName(receiver);
 
-        EssenceUserService qs = Sponge.getServiceManager().provideUnchecked(EssenceUserService.class);
+        EssenceUserLoaderService qs = Sponge.getServiceManager().provideUnchecked(EssenceUserLoaderService.class);
 
         // If a player, then mutes should be checked.
         if (sender instanceof Player) {

--- a/src/main/java/io/github/essencepowered/essence/internal/services/datastore/UserConfigLoader.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/services/datastore/UserConfigLoader.java
@@ -2,13 +2,13 @@
  * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
  * at the root of this project for more details.
  */
-package io.github.essencepowered.essence.internal.services;
+package io.github.essencepowered.essence.internal.services.datastore;
 
 import com.google.common.collect.Maps;
 import io.github.essencepowered.essence.Essence;
 import io.github.essencepowered.essence.api.data.EssenceUser;
 import io.github.essencepowered.essence.api.exceptions.NoSuchPlayerException;
-import io.github.essencepowered.essence.api.service.EssenceUserService;
+import io.github.essencepowered.essence.api.service.EssenceUserLoaderService;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class UserConfigLoader implements EssenceUserService {
+public class UserConfigLoader implements EssenceUserLoaderService {
 
     private final Essence plugin;
     private final Map<UUID, UserService> loadedUsers = Maps.newHashMap();

--- a/src/main/java/io/github/essencepowered/essence/internal/services/datastore/UserService.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/services/datastore/UserService.java
@@ -2,7 +2,7 @@
  * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
  * at the root of this project for more details.
  */
-package io.github.essencepowered.essence.internal.services;
+package io.github.essencepowered.essence.internal.services.datastore;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/io/github/essencepowered/essence/internal/services/datastore/WorldConfigLoader.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/services/datastore/WorldConfigLoader.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.internal.services.datastore;
+
+import com.google.common.collect.Maps;
+import io.github.essencepowered.essence.Essence;
+import io.github.essencepowered.essence.api.data.EssenceWorld;
+import io.github.essencepowered.essence.api.exceptions.NoSuchWorldException;
+import io.github.essencepowered.essence.api.service.EssenceWorldLoaderService;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.world.World;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Loader that loads configuration files for worlds.
+ */
+public class WorldConfigLoader implements EssenceWorldLoaderService {
+
+    private final Essence plugin;
+    private final Map<UUID, WorldService> loaded = Maps.newHashMap();
+
+    public WorldConfigLoader(Essence plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public EssenceWorld getWorld(UUID uuid) throws NoSuchWorldException, IOException, ObjectMappingException {
+        return getWorld(Sponge.getServer().getWorld(uuid).orElseThrow(NoSuchWorldException::new));
+    }
+
+    @Override
+    public EssenceWorld getWorld(World world) throws IOException, ObjectMappingException {
+        if (loaded.containsKey(world.getUniqueId())) {
+            return loaded.get(world.getUniqueId());
+        }
+
+        // Load the file in.
+        WorldService uc = new WorldService(plugin, getWorldPath(world.getUniqueId()), world);
+        loaded.put(world.getUniqueId(), uc);
+        return uc;
+    }
+
+    @Override
+    public void saveAll() {
+        loaded.values().forEach(c -> {
+            try {
+                c.save();
+            } catch (IOException | ObjectMappingException e) {
+                plugin.getLogger().error("Could not save data for " + c.getUniqueID().toString());
+                e.printStackTrace();
+            }
+        });
+    }
+
+    public Path getWorldPath(UUID uuid) throws IOException {
+        String u = uuid.toString();
+        String f = u.substring(0, 2);
+        Path file = plugin.getDataPath().resolve(String.format("worlddata%1$s%2$s%1$s%3$s.json", File.separator, f, u));
+
+        if (Files.notExists(file)) {
+            Files.createDirectories(file.getParent());
+        }
+
+        // Configurate will create it for us.
+        return file;
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/internal/services/datastore/WorldService.java
+++ b/src/main/java/io/github/essencepowered/essence/internal/services/datastore/WorldService.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.internal.services.datastore;
+
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+import io.github.essencepowered.essence.Essence;
+import io.github.essencepowered.essence.api.data.EssenceWorld;
+import io.github.essencepowered.essence.config.serialisers.WorldConfig;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.SimpleConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.world.World;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+public class WorldService implements EssenceWorld {
+
+    private final Essence plugin;
+
+    // TODO: Think about whether we need the world object, or just the UUID.
+    private final World world;
+    private final GsonConfigurationLoader loader;
+
+    private WorldConfig config = null;
+
+    public WorldService(Essence plugin, Path worldPath, World world) throws IOException, ObjectMappingException {
+        Preconditions.checkNotNull(world);
+        Preconditions.checkNotNull(worldPath);
+        Preconditions.checkNotNull(plugin);
+        this.plugin = plugin;
+        this.world = world;
+        this.loader = GsonConfigurationLoader.builder().setPath(worldPath).build();
+        load();
+    }
+
+    private void load() throws IOException, ObjectMappingException {
+        ConfigurationNode cn = loader.load();
+        config = cn.getValue(TypeToken.of(WorldConfig.class), new WorldConfig());
+    }
+
+    public void save() throws IOException, ObjectMappingException {
+        ConfigurationNode cn = SimpleConfigurationNode.root();
+        cn.setValue(TypeToken.of(WorldConfig.class), config);
+        loader.save(cn);
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public UUID getUniqueID() {
+        return world.getUniqueId();
+    }
+
+    @Override
+    public boolean isLockWeather() {
+        return config.isLockWeather();
+    }
+
+    @Override
+    public void setLockWeather(boolean lockWeather) {
+        config.setLockWeather(lockWeather);
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/listeners/ChatListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/ChatListener.java
@@ -10,7 +10,7 @@ import io.github.essencepowered.essence.api.PluginModule;
 import io.github.essencepowered.essence.config.MainConfig;
 import io.github.essencepowered.essence.internal.ListenerBase;
 import io.github.essencepowered.essence.internal.annotations.Modules;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;

--- a/src/main/java/io/github/essencepowered/essence/listeners/CoreListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/CoreListener.java
@@ -6,7 +6,7 @@ package io.github.essencepowered.essence.listeners;
 
 import io.github.essencepowered.essence.internal.ListenerBase;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;

--- a/src/main/java/io/github/essencepowered/essence/listeners/EnvironmentListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/EnvironmentListener.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.listeners;
+
+import com.google.inject.Inject;
+import io.github.essencepowered.essence.api.PluginModule;
+import io.github.essencepowered.essence.api.data.EssenceWorld;
+import io.github.essencepowered.essence.internal.ListenerBase;
+import io.github.essencepowered.essence.internal.annotations.Modules;
+import io.github.essencepowered.essence.internal.services.datastore.WorldConfigLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.world.ChangeWorldWeatherEvent;
+
+import java.io.IOException;
+
+@Modules(PluginModule.ENVIRONMENT)
+public class EnvironmentListener extends ListenerBase {
+
+    @Inject private WorldConfigLoader loader;
+
+    @Listener
+    public void onWeatherChange(ChangeWorldWeatherEvent event) {
+        try {
+            EssenceWorld ew = loader.getWorld(event.getTargetWorld());
+            event.setCancelled(ew.isLockWeather());
+        } catch (IOException | ObjectMappingException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/listeners/JailListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/JailListener.java
@@ -16,7 +16,7 @@ import io.github.essencepowered.essence.internal.ListenerBase;
 import io.github.essencepowered.essence.internal.annotations.Modules;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
 import io.github.essencepowered.essence.internal.services.JailHandler;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;

--- a/src/main/java/io/github/essencepowered/essence/listeners/MuteListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/MuteListener.java
@@ -11,7 +11,7 @@ import io.github.essencepowered.essence.api.data.EssenceUser;
 import io.github.essencepowered.essence.api.data.MuteData;
 import io.github.essencepowered.essence.internal.ListenerBase;
 import io.github.essencepowered.essence.internal.annotations.Modules;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;

--- a/src/main/java/io/github/essencepowered/essence/listeners/NicknameListener.java
+++ b/src/main/java/io/github/essencepowered/essence/listeners/NicknameListener.java
@@ -9,7 +9,7 @@ import io.github.essencepowered.essence.api.PluginModule;
 import io.github.essencepowered.essence.internal.ListenerBase;
 import io.github.essencepowered.essence.internal.annotations.Modules;
 import io.github.essencepowered.essence.internal.interfaces.InternalEssenceUser;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;

--- a/src/main/java/io/github/essencepowered/essence/runnables/CoreTask.java
+++ b/src/main/java/io/github/essencepowered/essence/runnables/CoreTask.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Essence, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.essencepowered.essence.runnables;
+
+import com.google.inject.Inject;
+import io.github.essencepowered.essence.Essence;
+import io.github.essencepowered.essence.internal.TaskBase;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.WorldConfigLoader;
+import org.spongepowered.api.scheduler.Task;
+
+/**
+ * Core tasks. No module, must always run.
+ */
+public class CoreTask extends TaskBase {
+    @Inject private Essence plugin;
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+
+    @Override
+    public int secondsPerRun() {
+        return 30;
+    }
+
+    @Override
+    public void accept(Task task) {
+        UserConfigLoader ucl = plugin.getUserLoader();
+        ucl.purgeNotOnline();
+        ucl.saveAll();
+
+        WorldConfigLoader wcl = plugin.getWorldLoader();
+        wcl.saveAll();
+    }
+}

--- a/src/main/java/io/github/essencepowered/essence/runnables/JailTask.java
+++ b/src/main/java/io/github/essencepowered/essence/runnables/JailTask.java
@@ -9,7 +9,7 @@ import io.github.essencepowered.essence.Util;
 import io.github.essencepowered.essence.api.PluginModule;
 import io.github.essencepowered.essence.internal.TaskBase;
 import io.github.essencepowered.essence.internal.annotations.Modules;
-import io.github.essencepowered.essence.internal.services.UserConfigLoader;
+import io.github.essencepowered.essence.internal.services.datastore.UserConfigLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -177,6 +177,7 @@ command.socialspy.unable=Your social spy status could not be set.
 
 command.weather=You set the weather to {0} in the world {1}.
 command.weather.time=You set the weather to {0} in the world {1} for {2}.
+command.weather.locked=The weather is locked for the world {0}. It must be unlocked to change the weather.
 
 command.settime.default=No world was specified - the default was used.
 command.settime.done=The time on the world has been set to {0}.
@@ -358,6 +359,11 @@ command.exp.set.new.other={0} now has {1} experience points (level {2}).
 command.exp.set.new=You now have {0} experience points (level {1}).
 
 command.printperms=The suggested permissions have been written to {0}
+
+command.lockweather.locked=The weather has been locked in the world {0}.
+command.lockweather.unlocked=The weather has been unlocked in the world {0}.
+
+command.specifyworld=The world must be specified.
 
 # Ban
 ban.defaultreason=The banhammer has spoken!


### PR DESCRIPTION
This is to allow for world specific data to be stored. This is the PR for #10. However, @hsyyid might be interested in looking at this now and getting an idea for what data may need storing on the world level.

* Now add world data to essence/worlddata/ab/<uuid>.json
* Some moving of packages have occurred, this is to allow for some code de-duplication later.
* Move some free-floating tasks into their own class - now loaded by the PluginSystemsLoader

This needs to be tested at some point. Do not merge yet.